### PR TITLE
Define STRICT_R_HEADERS and include cfloat

### DIFF
--- a/src/decimal_to_fraction.cpp
+++ b/src/decimal_to_fraction.cpp
@@ -1,3 +1,5 @@
+#define STRICT_R_HEADERS
+#include <cfloat>
 #include <Rcpp.h>
 using namespace Rcpp;
 

--- a/src/lcm.cpp
+++ b/src/lcm.cpp
@@ -1,3 +1,4 @@
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 #include <limits>
 #include <numeric>


### PR DESCRIPTION
Dear Alexander,

Your CRAN package fracture uses Rcpp, and is affected if we add a definition of STRICT_R_HEADERS as we would like to do. Please see the discussion at https://github.com/RcppCore/Rcpp/issues/1158 and the links therein for more context on this.

Here, we prefixed each #include <Rcpp.h> with STRICT_R_HEADERS and included cfloat (alternatively float.h could be used C style). No other changes are needed.

It would be lovely if you could apply this. There is no strong urgency: we aim to get this done over all affected packages in the space of a few months. If you apply it, would you mind dropping me a note by email or swinging by https://github.com/RcppCore/Rcpp/issues/1158 to confirm?

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.