### PR TITLE
Add argument `denom` to explicitly set a denominator

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fracture
 Title: Convert Decimals to Fractions
-Version: 0.1.3
+Version: 0.1.3.9000
 Authors@R: 
     person(given = "Alexander",
            family = "Rossell Hayes",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,6 @@ LinkingTo:
     Rcpp
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 SystemRequirements: C++11
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
     Rcpp
 Suggests: 
     covr,
-    testthat,
+    testthat (>= 3.0.0),
     withr
 LinkingTo: 
     Rcpp
@@ -33,3 +33,4 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 SystemRequirements: C++11
+Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # fracture (development version)
 
+## Breaking changes
+* The second argument to `fracture()` and `frac_mat()` is now `...`, which must be empty. As a result, all arguments besides `x` must now be named. (#5)
+
+## New features
+* `fracture()` and `frac_mat()` gain the argument `denom`, which allows the user to set an explicit denominator used by all fractions. (#5)
+
+## Miscellaneous
+* Updated `testthat` to 3rd edition.
+
 # fracture 0.1.3
 
 * Implemented STRICT_R_HEADERS in accordance with RcppCore/Rcpp#1158

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# fracture (development version)
+
 # fracture 0.1.3
 
 * Implemented STRICT_R_HEADERS in accordance with RcppCore/Rcpp#1158

--- a/R/check_dots_empty0.R
+++ b/R/check_dots_empty0.R
@@ -1,0 +1,26 @@
+check_dots_empty0 <- function(..., match.call) {
+  if (!empty(...)) {
+    call        <- as.list(match.call[-1])
+    dots        <- call[lapply(call, eval) %in% list(...)]
+    names       <- names(dots)
+    named       <- which(names != "")
+    args        <- vapply(dots, deparse, character(1))
+    args[named] <- paste(names[named], "=", args[named])
+
+    stop(
+      paste(
+        "`...` is not empty.",
+        "These dots only exist to allow future extensions and should be empty.",
+        "We detected these problematic arguments:",
+        paste0("* `", args, "`", collapse = "\n"),
+        "Did you misspecify an argument?",
+        sep = "\n"
+      ),
+      call. = FALSE
+    )
+  }
+}
+
+empty <- function(...) {
+  nargs() == 0
+}

--- a/R/fracture.R
+++ b/R/fracture.R
@@ -11,13 +11,17 @@
 #' @example examples/fracture.R
 
 fracture <- function(
-  x, base_10 = FALSE, common_denom = FALSE, mixed = FALSE, max_denom = 1e7
+  x, ..., denom = NULL,
+  base_10 = FALSE, common_denom = FALSE, mixed = FALSE, max_denom = 1e7
 ) {
+  check_dots_empty0(..., match.call = match.call())
+
   op <- options(scipen = 100)
   on.exit(options(op), add = TRUE)
 
   matrix <- frac_mat(
     x            = x,
+    denom        = denom,
     base_10      = base_10,
     common_denom = common_denom,
     mixed        = mixed,

--- a/man/frac_mat.Rd
+++ b/man/frac_mat.Rd
@@ -8,6 +8,8 @@
 \usage{
 frac_mat(
   x,
+  ...,
+  denom = NULL,
   base_10 = FALSE,
   common_denom = FALSE,
   mixed = FALSE,
@@ -21,6 +23,12 @@ is.frac_mat(x)
 \arguments{
 \item{x}{A vector of decimals or, for \code{as.frac_mat()}, a character vector
 created by \code{\link[=fracture]{fracture()}}}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{denom}{If \code{denom} is not \code{\link{NULL}}, all fractions will have a
+denominator of \code{denom}. This will ignore all other arguments that affect
+the denominator.}
 
 \item{base_10}{If \code{TRUE}, all denominators will be a power of 10.}
 

--- a/man/fracture-package.Rd
+++ b/man/fracture-package.Rd
@@ -8,14 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
 
-Provides functions for converting decimals to a
-    matrix of numerators and denominators or a character vector of
-    fractions.  Supports mixed or improper fractions, finding common
-    denominators for vectors of fractions, limiting denominators to powers
-    of ten, and limiting denominators to a maximum value.  Also includes
-    helper functions for finding the least common multiple and greatest
-    common divisor for a vector of integers.  Implemented using C++ for
-    maximum speed.
+Provides functions for converting decimals to a matrix of numerators and denominators or a character vector of fractions. Supports mixed or improper fractions, finding common denominators for vectors of fractions, limiting denominators to powers of ten, and limiting denominators to a maximum value. Also includes helper functions for finding the least common multiple and greatest common divisor for a vector of integers. Implemented using C++ for maximum speed.
 }
 \seealso{
 Useful links:

--- a/man/fracture.Rd
+++ b/man/fracture.Rd
@@ -8,6 +8,8 @@
 \usage{
 fracture(
   x,
+  ...,
+  denom = NULL,
   base_10 = FALSE,
   common_denom = FALSE,
   mixed = FALSE,
@@ -21,6 +23,12 @@ is.fracture(x)
 \arguments{
 \item{x}{A vector of decimals or, for \code{as.fracture()}, a matrix created by
 \code{\link[=frac_mat]{frac_mat()}}}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{denom}{If \code{denom} is not \code{\link{NULL}}, all fractions will have a
+denominator of \code{denom}. This will ignore all other arguments that affect
+the denominator.}
 
 \item{base_10}{If \code{TRUE}, all denominators will be a power of 10.}
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // decimal_to_fraction
 IntegerMatrix decimal_to_fraction(const NumericVector x, const bool base_10, const long max_denom);
 RcppExport SEXP _fracture_decimal_to_fraction(SEXP xSEXP, SEXP base_10SEXP, SEXP max_denomSEXP) {

--- a/tests/testthat/_snaps/check_dots_empty0.md
+++ b/tests/testthat/_snaps/check_dots_empty0.md
@@ -1,0 +1,50 @@
+# empty dots
+
+    `...` is not empty.
+    These dots only exist to allow future extensions and should be empty.
+    We detected these problematic arguments:
+    * `"test"`
+    Did you misspecify an argument?
+
+---
+
+    `...` is not empty.
+    These dots only exist to allow future extensions and should be empty.
+    We detected these problematic arguments:
+    * `z = 20`
+    Did you misspecify an argument?
+
+---
+
+    `...` is not empty.
+    These dots only exist to allow future extensions and should be empty.
+    We detected these problematic arguments:
+    * `"test"`
+    * `z = letters`
+    Did you misspecify an argument?
+
+---
+
+    `...` is not empty.
+    These dots only exist to allow future extensions and should be empty.
+    We detected these problematic arguments:
+    * `list(1:10)`
+    Did you misspecify an argument?
+
+---
+
+    `...` is not empty.
+    These dots only exist to allow future extensions and should be empty.
+    We detected these problematic arguments:
+    * `z = c(letters, 20)`
+    Did you misspecify an argument?
+
+---
+
+    `...` is not empty.
+    These dots only exist to allow future extensions and should be empty.
+    We detected these problematic arguments:
+    * `list(1:10)`
+    * `z = c(letters, 20)`
+    Did you misspecify an argument?
+

--- a/tests/testthat/test-check_dots_empty0.R
+++ b/tests/testthat/test-check_dots_empty0.R
@@ -1,0 +1,8 @@
+test_that("empty dots", {
+  expect_snapshot_error(fracture(1, "test"))
+  expect_snapshot_error(fracture(1, z = 20))
+  expect_snapshot_error(fracture(1, "test", z = letters))
+  expect_snapshot_error(fracture(1, list(1:10)))
+  expect_snapshot_error(fracture(1, z = c(letters, 20)))
+  expect_snapshot_error(fracture(1, list(1:10), z =c(letters, 20)))
+})

--- a/tests/testthat/test-frac_mat.R
+++ b/tests/testthat/test-frac_mat.R
@@ -1,3 +1,7 @@
+expect_equivalent <- function(...) {
+  testthat::expect_equal(..., ignore_attr = TRUE)
+}
+
 test_that("scalar frac_mat()", {
   mat <- frac_mat(0.5)
   expect_equivalent(mat, c(1, 2))

--- a/tests/testthat/test-frac_style.R
+++ b/tests/testthat/test-frac_style.R
@@ -14,38 +14,3 @@ test_that("frac_style() coerces to fracture", {
   expect_equal(frac_style(0.5), "¹/₂")
   expect_equal(frac_style(1.5, mixed = TRUE), "1 ¹/₂")
 })
-
-# expect_comparable <- function(object, expected, ...) {
-#   object   <- unclass(object)
-#   expected <- unclass(expected)
-#   expect_equivalent(object, expected, ...)
-# }
-#
-# test_that("simple frac_style()", {
-#   expect_comparable(frac_style(fracture(0.5)), fracture(0.5))
-#   expect_output(print(frac_style(fracture(0.5))), "¹/₂")
-# })
-#
-# test_that("mixed frac_style()", {
-#   expect_comparable(
-#     frac_style(fracture(1.5, mixed = TRUE)), fracture(1.5, mixed = TRUE)
-#   )
-#   expect_output(print(frac_style(fracture(1.5, mixed = TRUE))), "1 ¹/₂")
-# })
-#
-# test_that("vector frac_style()", {
-#   expect_comparable(frac_style(fracture(c(0.5, 1.5))), fracture(c(0.5, 1.5)))
-#   expect_output(print(frac_style(fracture(c(0.5, 1.5)))), "¹/₂ ³/₂")
-# })
-#
-# test_that("frac_style() coerces to fracture", {
-#   expect_comparable(frac_style(0.5), fracture(0.5))
-#   expect_output(print(frac_style(0.5)), "¹/₂")
-#
-#   expect_comparable(frac_style(1.5, mixed = TRUE), fracture(1.5, mixed = TRUE))
-#   expect_output(print(frac_style(1.5, mixed = TRUE)), "1 ¹/₂")
-# })
-#
-# test_that("frac_style() math", {
-#   expect_equal(frac_style(fracture(c(0.5, 1.5))) + 1, fracture(c(0.5, 1.5)) + 1)
-# })

--- a/tests/testthat/test-fracture.R
+++ b/tests/testthat/test-fracture.R
@@ -69,6 +69,19 @@ test_that("really long vector fracture()", {
   expect_comparable(fracture(test_decimal), test_fraction)
 })
 
+test_that("explicit denom fracture()", {
+  expect_comparable(fracture(2 / 11, denom = 10), "2/10")
+  expect_comparable(
+    fracture(rep(2 / 11, 2), denom = c(10, 12)), c("2/10", "2/12")
+  )
+  expect_comparable(
+    fracture(24 / 11, denom = 10, mixed = TRUE), "2 2/10"
+  )
+  expect_comparable(
+    fracture(c(6, 20) / 11, denom = 10, mixed = TRUE), c("5/10", "1 8/10")
+  )
+})
+
 test_that("improper fracture()", {
   expect_comparable(fracture(c(1.5, 2)), c("3/2", "2/1"))
   expect_comparable(as.fracture(c(1.5, 2)), c("3/2", "2/1"))
@@ -307,4 +320,8 @@ test_that("fracture() errors", {
   expect_error(fracture(Inf))
   expect_error(fracture(-Inf))
   expect_error(fracture(c(0.5, NA, 1.5)))
+  expect_error(fracture(1, denom = NA))
+  expect_error(fracture(1, denom = Inf))
+  expect_error(fracture(1, denom = 1:2))
+  expect_error(fracture(1:10, denom = 1:2))
 })

--- a/tests/testthat/test-fracture.R
+++ b/tests/testthat/test-fracture.R
@@ -1,7 +1,5 @@
 expect_comparable <- function(object, expected, ...) {
-  object   <- unclass(object)
-  expected <- unclass(expected)
-  expect_equivalent(object, expected, ...)
+  testthat::expect_equal(object, expected, ..., ignore_attr = TRUE)
 }
 
 test_that("scalar fracture()", {


### PR DESCRIPTION
``` r
library(fracture)

1:6 / 6:1
#> [1] 0.1666667 0.4000000 0.7500000 1.3333333 2.5000000 6.0000000
fracture(1:6 / 6:1, denom = 20)
#> [1] 3/20   8/20   15/20  27/20  50/20  120/20
```

<sup>Created on 2021-10-16 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>