### PR TITLE
Make `fracture(0)` and `fracture(1)` default to denominators of `1`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fracture
 Title: Convert Decimals to Fractions
-Version: 0.1.3.9000
+Version: 0.1.3.9001
 Authors@R: 
     person(given = "Alexander",
            family = "Rossell Hayes",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Breaking changes
 * The second argument to `fracture()` and `frac_mat()` is now `...`, which must be empty. As a result, all arguments besides `x` must now be named. (#5)
+* `fracture()` and `frac_mat()` now default to a denominator of `1` when `x` equals `0` or `1`. Previously, these would default to a denominator of `max_denom`. `max_denom` is still used as the denominator when `x` is `0` or `1` ± ε. (#6)
 
 ## New features
 * `fracture()` and `frac_mat()` gain the argument `denom`, which allows the user to set an explicit denominator used by all fractions. (#5)

--- a/R/frac_mat.R
+++ b/R/frac_mat.R
@@ -85,20 +85,24 @@ frac_mat <- function(
   integer <- ((x > 0) * 1 + (x < 0) * -1) * (abs(x) %/% 1)
   decimal <- x - integer
 
-  matrix <- decimal_to_fraction(decimal, base_10, max_denom)
+  matrix                 <- rbind(decimal, decimal)
+  matrix[, decimal == 0] <- c(0, 1)
+  matrix[, decimal != 0] <- decimal_to_fraction(
+    decimal[decimal != 0], base_10, max_denom
+  )
+  rownames(matrix) <- c("numerator", "denominator")
 
   if (common_denom) {
     denom       <- lcm(matrix[2, ], max_denom)
     matrix[1, ] <- round(matrix[1, ] * (denom / matrix[2, ]))
     matrix[2, ] <- denom
   } else {
-    extrema           <- which(
-      (matrix[1, ] == 1 & matrix[2, ] == 1) | (matrix[1, ] == 0 & integer == 0)
+    extrema <- which(
+      (matrix[1, ] == matrix[2, ] & decimal != 1) |
+      (matrix[1, ] == 0 & decimal != 0)
     )
     matrix[, extrema] <- matrix[, extrema] * max_denom
   }
-
-  rownames(matrix) <- c("numerator", "denominator")
 
   if (mixed) {
     matrix              <- rbind(integer, matrix)

--- a/tests/testthat/test-fracture.R
+++ b/tests/testthat/test-fracture.R
@@ -19,6 +19,21 @@ test_that("small fracture()", {
   expect_comparable(as.fracture(1 / 1e5), "1/100000")
 })
 
+test_that("extreme fracture()", {
+  expect_comparable(fracture(0), "0/1")
+  expect_comparable(fracture(.Machine$double.eps), "0/10000000")
+  expect_comparable(fracture(1), "1/1")
+  expect_comparable(fracture(1 - .Machine$double.eps), "10000000/10000000")
+
+  expect_comparable(
+    fracture(
+      c(0, .Machine$double.eps, 1/5, 1 - .Machine$double.eps, 1),
+      common_denom = TRUE
+    ),
+    c("0/5", "0/5", "1/5", "5/5", "5/5")
+  )
+})
+
 test_that("irrational fracture()", {
   expect_comparable(fracture(pi, max_denom = 100), "22/7")
 })


### PR DESCRIPTION
Previously `fracture()` would use `max_denom` as the denominator when `x == 0` or `x == 1`. Now, `fracture()` will use `1`.

``` r
library(fracture)

fracture(0)
#> [1] 0/1
fracture(1)
#> [1] 1/1
```

Existing behavior is retained when x ≈ 0 or 1.

``` r
fracture(.Machine$double.eps)
#> [1] 0/10000000
fracture(1 - .Machine$double.eps)
#> [1] 10000000/10000000
```

The denominator can still be changed with arguments like `common_denom`.

``` r
fracture(c(0, 1/5, 1), common_denom = TRUE)
#> [1] 0/5 1/5 5/5
```

<sup>Created on 2021-10-16 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Closes #4.