### PR TITLE
Wrap quotes around mixed fractions in `print.fracture()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fracture
 Title: Convert Decimals to Fractions
-Version: 0.1.3.9001
+Version: 0.1.3.9002
 Authors@R: 
     person(given = "Alexander",
            family = "Rossell Hayes",

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,8 @@
 * `fracture()` and `frac_mat()` gain the argument `denom`, which allows the user to set an explicit denominator used by all fractions. (#5)
 
 ## Miscellaneous
-* Updated `testthat` to 3rd edition.
+* The `print()` method for `fracture`s now puts quotes around mixed fractions to increase legibility. (#7)
+* Updated `testthat` to 3rd edition. (#5)
 
 # fracture 0.1.3
 

--- a/R/fracture.R
+++ b/R/fracture.R
@@ -102,7 +102,12 @@ as.integer.fracture <- function(x, ...) {
 
 print.fracture <- function(x, ...) {
   x <- as.character(x)
-  NextMethod("print", quote = FALSE)
+  NextMethod(
+    "print",
+    # Include quotes if there are any mixed fractions (e.g. "1 1/2") OR
+    # if there is a mix of fractions and integers (e.g. "1" "1/2")
+    quote = any(grepl(" ", x)) || length(unique(grepl("/", x))) > 1
+  )
 }
 
 #' @export


### PR DESCRIPTION
Updates the `print()` method for `fracture`s to put quotes around mixed fractures: either `fracture`s that contain both an integer and fractional component, or vectors that include both integers and fractions.

``` r
library(fracture)

fracture(3/2)
#> [1] 3/2
fracture(3/2, mixed = TRUE)
#> [1] "1 1/2"

fracture(c(1, 1/2))
#> [1] 1/1 1/2
fracture(c(1, 1/2), mixed = TRUE)
#> [1] "1"   "1/2"
```

<sup>Created on 2021-10-16 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>