### PR TITLE
Fix bug where `frac_style()` would include `0/0` in mixed fractions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fracture
 Title: Convert Decimals to Fractions
-Version: 0.2.0
+Version: 0.2.0.9000
 Authors@R: 
     person(given = "Alexander",
            family = "Rossell Hayes",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# fracture (development version)
+
 # fracture 0.2.0
 
 ## Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # fracture (development version)
 
+## Bug fixes
+* Fixed a bug where `frac_style()` would print integers in mixed `fracture`s as "1 ⁰/₀" instead of "1" (#12).
+
 # fracture 0.2.0
 
 ## Breaking changes

--- a/R/frac_style.R
+++ b/R/frac_style.R
@@ -15,14 +15,21 @@ frac_style <- function(fracture, ...) {
   if (!is.fracture(fracture)) {fracture <- fracture(fracture, ...)}
   frac_style <- as.frac_mat(fracture)
 
+  if (nrow(frac_style) == 3) {
+    zeroes <- frac_style[2, ] == 0 & frac_style[3, ] %in% c(0, 1)
+  } else {
+    zeroes <- FALSE
+  }
+
   frac_style[] <- as.character(frac_style)
-  frac_style["numerator", ] <- vapply(
-    strsplit(frac_style["numerator", ], ""),
+
+  frac_style["numerator", !zeroes] <- vapply(
+    strsplit(frac_style["numerator", !zeroes], ""),
     function(x) paste(numerators[as.numeric(x) + 1], collapse = ""),
     character(1)
   )
-  frac_style["denominator", ] <- vapply(
-    strsplit(frac_style["denominator", ], ""),
+  frac_style["denominator", !zeroes] <- vapply(
+    strsplit(frac_style["denominator", !zeroes], ""),
     function(x) paste(denominators[as.numeric(x) + 1], collapse = ""),
     character(1)
   )

--- a/R/fracture.R
+++ b/R/fracture.R
@@ -59,7 +59,7 @@ as.fracture_numeric <- function(x) {
 as.fracture_paste <- function(x) {
   if (nrow(x) == 3) {
     x              <- rbind(x[1, ], " ", x[2, ], "/", x[3, ])
-    no_frac        <- which(x[3, ] == 0)
+    no_frac        <- which(x[3, ] == 0 & x[5, ] %in% c(0, 1))
     x[-1, no_frac] <- ""
     no_int         <- which(x[1, ] == 0)
     x[1:2, no_int] <- ""


### PR DESCRIPTION
``` r
library(fracture)
frac_style(fracture(c((1:3) / 2, .Machine$double.eps), mixed = TRUE))
#> [1] "¹/₂"        "1"          "1 ¹/₂"      "⁰/₁₀₀₀₀₀₀₀"
```

<sup>Created on 2021-10-31 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Closes #10.