### PR TITLE
Support `NA` and `Inf` values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fracture
 Title: Convert Decimals to Fractions
-Version: 0.2.0.9000
+Version: 0.2.0.9001
 Authors@R: 
     person(given = "Alexander",
            family = "Rossell Hayes",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,12 @@
 # fracture (development version)
 
+## New features
+* `fracture()` and `frac_mat()` no longer return an error when receiving a vector containing `NA` or `Inf` values (#14).
+  * `fracture(NA)` now returns `NA`.
+  * `fracture(Inf)` now returns `"Inf/1"`.
+
 ## Bug fixes
-* Fixed a bug where `frac_style()` would print integers in mixed `fracture`s as "1 ⁰/₀" instead of "1" (#12).
+* Fixed a bug where `frac_style()` would print integers in mixed `fracture`s as `"1 ⁰/₀"` instead of `"1"` (#12).
 
 # fracture 0.2.0
 

--- a/R/frac_mat.R
+++ b/R/frac_mat.R
@@ -45,7 +45,10 @@ frac_mat <- function(
 ) {
   check_dots_empty0(..., match.call = match.call())
 
-  if (!is.numeric(x) || any(is.na(x)) || any(is.infinite(x))) {
+  if (length(x) == 0) {return(x)}
+  if (all(is.na(x)))  {return(x)}
+
+  if (!is.numeric(x)) {
     stop("`x` must be a vector of finite numbers.", call. = FALSE)
   }
 
@@ -81,22 +84,25 @@ frac_mat <- function(
     )
   }
 
-  integer <- ifelse(x >= 0, x %/% 1, (x %/% 1 + 1))
-  integer <- ((x > 0) * 1 + (x < 0) * -1) * (abs(x) %/% 1)
-  decimal <- x - integer
+  result  <- numeric(length(x))
+  numbers <- x[is.finite(x)]
+
+  integer <- ((numbers > 0) * 1 + (numbers < 0) * -1) * (abs(numbers) %/% 1)
+  decimal <- numbers - integer
 
   matrix                 <- rbind(decimal, decimal)
   matrix[, decimal == 0] <- c(0, 1)
   matrix[, decimal != 0] <- decimal_to_fraction(
     decimal[decimal != 0], base_10, max_denom
   )
-  rownames(matrix) <- c("numerator", "denominator")
 
   if (common_denom) {
     denom       <- lcm(matrix[2, ], max_denom)
     matrix[1, ] <- round(matrix[1, ] * (denom / matrix[2, ]))
     matrix[2, ] <- denom
   } else {
+    denom <- 1
+
     extrema <- which(
       (matrix[1, ] == matrix[2, ] & decimal != 1) |
       (matrix[1, ] == 0 & decimal != 0)
@@ -108,11 +114,29 @@ frac_mat <- function(
     matrix              <- rbind(integer, matrix)
     negative            <- which(matrix[1, ] < 0)
     matrix[2, negative] <- abs(matrix[2, negative])
+
+    result <- rbind(
+      integer = result, numerator = result, denominator = result
+    )
+    result[, is.finite(x)] <- matrix
+    result[, is.na(x)]     <- rbind(NA, NA, NA)
+
+    if (any(is.infinite(x))) {
+      result[, is.infinite(x)] <- rbind(x[is.infinite(x)], 0, denom)
+    }
   } else {
     matrix[1, ] <- integer * matrix[2, ] + matrix[1, ]
+
+    result                 <- rbind(numerator = result, denominator = result)
+    result[, is.finite(x)] <- matrix
+    result[, is.na(x)]     <- rbind(NA, NA)
+
+    if (any(is.infinite(x))) {
+      result[, is.infinite(x)] <- rbind(x[is.infinite(x)], denom)
+    }
   }
 
-  matrix
+  result
 }
 
 #' @rdname frac_mat
@@ -144,9 +168,11 @@ as.frac_mat <- function(x) {
 #' @export
 
 is.frac_mat <- function(x) {
+  numbers <- x[is.finite(x)]
+
   is.matrix(x) &&
     is.numeric(x) &&
-    all(x %% 1 == 0) &&
+    all(numbers %% 1 == 0) &&
     nrow(x) %in% 2:3 &&
     !is.null(rownames(x)) &&
     all(rownames(x) %in% c("integer", "numerator", "denominator"))

--- a/R/frac_mat.R
+++ b/R/frac_mat.R
@@ -46,10 +46,13 @@ frac_mat <- function(
   check_dots_empty0(..., match.call = match.call())
 
   if (length(x) == 0) {return(x)}
-  if (all(is.na(x)))  {return(x)}
 
   if (!is.numeric(x)) {
-    stop("`x` must be a vector of finite numbers.", call. = FALSE)
+    if (all(is.na(x))) {
+      x <- as.integer(x)
+    } else {
+      stop("`x` must be a vector of numbers.", call. = FALSE)
+    }
   }
 
   if (!is.null(denom)) {

--- a/R/fracture.R
+++ b/R/fracture.R
@@ -16,6 +16,9 @@ fracture <- function(
 ) {
   check_dots_empty0(..., match.call = match.call())
 
+  if (length(x) == 0) {return(x)}
+  if (all(is.na(x)))  {return(x)}
+
   op <- options(scipen = 100)
   on.exit(options(op), add = TRUE)
 
@@ -57,17 +60,25 @@ as.fracture_numeric <- function(x) {
 }
 
 as.fracture_paste <- function(x) {
-  if (nrow(x) == 3) {
-    x              <- rbind(x[1, ], " ", x[2, ], "/", x[3, ])
-    no_frac        <- which(x[3, ] == 0 & x[5, ] %in% c(0, 1))
-    x[-1, no_frac] <- ""
-    no_int         <- which(x[1, ] == 0)
-    x[1:2, no_int] <- ""
+  result  <- character(ncol(x))
+  na      <- is.na(x[1, ])
+  numbers <- matrix(x[, !na], nrow = nrow(x))
 
-    as.character(apply(x, 2, paste0, collapse = ""))
+  if (nrow(numbers) == 3) {
+    numbers <- rbind(numbers[1, ], " ", numbers[2, ], "/", numbers[3, ])
+    no_frac <- which(numbers[3, ] == 0 & numbers[5, ] %in% c(0, 1))
+    numbers[-1, no_frac] <- ""
+
+    no_int <- which(numbers[1, ] == 0)
+    numbers[1:2, no_int] <- ""
+
+    result[!na] <- as.character(apply(numbers, 2, paste0, collapse = ""))
   } else {
-    paste0(x[1, ], "/", x[2, ])
+    result[!na] <- paste0(numbers[1, ], "/", numbers[2, ])
   }
+
+  result[na] <- NA
+  result
 }
 
 #' @rdname fracture

--- a/tests/testthat/test-frac_mat.R
+++ b/tests/testthat/test-frac_mat.R
@@ -173,3 +173,16 @@ test_that("is.frac_mat()", {
   expect_false(is.frac_mat(frac_mat(1.5)[1, ]))
   expect_false(is.frac_mat(`rownames<-`(frac_mat(1.5), NULL)))
 })
+
+test_that("frac_mat(NA)", {
+  expect_equal(
+    frac_mat(NA),
+    rbind(numerator = NA_integer_, denominator = NA_integer_)
+  )
+  expect_equal(
+    frac_mat(NA, mixed = TRUE),
+    rbind(
+      integer = NA_integer_, numerator = NA_integer_, denominator = NA_integer_
+    )
+  )
+})

--- a/tests/testthat/test-frac_mat.R
+++ b/tests/testthat/test-frac_mat.R
@@ -186,3 +186,7 @@ test_that("frac_mat(NA)", {
     )
   )
 })
+
+test_that("early returns", {
+  expect_equal(frac_mat(numeric(0)), numeric(0))
+})

--- a/tests/testthat/test-fracture.R
+++ b/tests/testthat/test-fracture.R
@@ -330,11 +330,18 @@ test_that("recover_fracture_args()", {
   expect_null(recover_fracture_args(0, 0))
 })
 
+test_that("non-finite fracture()", {
+  expect_comparable(fracture(NA), NA)
+  expect_comparable(fracture(c(0.5, NA, 1.5)), c("1/2", NA, "3/2"))
+
+  expect_comparable(fracture(Inf), "Inf/1")
+  expect_comparable(fracture(-Inf), "-Inf/1")
+
+  expect_comparable(fracture(Inf,  mixed = TRUE), "Inf")
+  expect_comparable(fracture(-Inf, mixed = TRUE), "-Inf")
+})
+
 test_that("fracture() errors", {
-  expect_error(fracture(NA))
-  expect_error(fracture(Inf))
-  expect_error(fracture(-Inf))
-  expect_error(fracture(c(0.5, NA, 1.5)))
   expect_error(fracture(1, denom = NA))
   expect_error(fracture(1, denom = Inf))
   expect_error(fracture(1, denom = 1:2))

--- a/tests/testthat/test-fracture.R
+++ b/tests/testthat/test-fracture.R
@@ -341,7 +341,14 @@ test_that("non-finite fracture()", {
   expect_comparable(fracture(-Inf, mixed = TRUE), "-Inf")
 })
 
+test_that("early returns", {
+  expect_equal(fracture(numeric(0)), numeric(0))
+  expect_equal(fracture(NA), NA)
+  expect_equal(fracture(NA, mixed = TRUE), NA)
+})
+
 test_that("fracture() errors", {
+  expect_error(fracture(character(1)))
   expect_error(fracture(1, denom = NA))
   expect_error(fracture(1, denom = Inf))
   expect_error(fracture(1, denom = 1:2))


### PR DESCRIPTION
``` r
library(fracture)

fracture(c(NA, Inf, -Inf, 0.5))
#> [1] NA       "Inf/1"  "-Inf/1" "1/2"

fracture(c(NA, Inf, -Inf, 0.5), mixed = TRUE)
#> [1] NA     "Inf"  "-Inf" "1/2"

frac_mat(c(NA, Inf, -Inf, 0.5))
#>             [,1] [,2] [,3] [,4]
#> numerator     NA  Inf -Inf    1
#> denominator   NA    1    1    2

frac_mat(c(NA, Inf, -Inf, 0.5), mixed = TRUE)
#>             [,1] [,2] [,3] [,4]
#> integer       NA  Inf -Inf    0
#> numerator     NA    0    0    1
#> denominator   NA    1    1    2
```

<sup>Created on 2021-11-02 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Closes #13.